### PR TITLE
Handle disposed IOCP handle while closing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Implementation of the `PEP 3156`_ Event-Loop with Qt
 
 Requirements
 ============
-Quamash requires Python 3.4 or Python 3.3 with the backported ``asycnio`` library and either PyQt4, PyQt5 or PySide.
+Quamash requires Python 3.4 or Python 3.3 with the backported ``asyncio`` library and either PyQt4, PyQt5 or PySide.
 
 Installation
 ============

--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -557,6 +557,7 @@ class QEventLoop(_baseclass):
 			return
 
 		try:
+			self._logger.debug('Calling client exception handler')
 			self.__exception_handler(self, context)
 		except Exception as exc:
 			# Exception in the user set custom exception handler.

--- a/quamash/_windows.py
+++ b/quamash/_windows.py
@@ -77,9 +77,12 @@ class _IocpProactor(windows_events.IocpProactor):
 		"""Override in order to handle events in a threadsafe manner."""
 		if timeout is None:
 			ms = UINT32_MAX  # wait for eternity
-		elif timeout < 0:
-			raise ValueError("negative timeout")
 		else:
+			if not isinstance(timeout, (int, float)):
+				raise TypeError('timeout must be a number')
+			if timeout < 0:
+				raise ValueError("negative timeout")
+
 			# GetQueuedCompletionStatus() has a resolution of 1 millisecond,
 			# round away from zero to wait *at least* timeout seconds.
 			ms = math.ceil(timeout * 1e3)
@@ -89,8 +92,14 @@ class _IocpProactor(windows_events.IocpProactor):
 		while True:
 			# self._logger.debug('Polling IOCP with timeout {} ms in thread {}...'.format(
 			# 	ms, threading.get_ident()))
+			if self._iocp is None:
+				self._logger.debug('Stopping polling since IOCP handle is disposed')
+				break
+
+			assert 0 <= ms <= UINT32_MAX
 			status = _overlapped.GetQueuedCompletionStatus(self._iocp, ms)
 			if status is None:
+				self._logger.debug('Stopping polling since None was returned for status')
 				break
 
 			err, transferred, key, address = status

--- a/quamash/_windows.py
+++ b/quamash/_windows.py
@@ -39,7 +39,7 @@ class _ProactorEventLoop(QtCore.QObject, asyncio.ProactorEventLoop):
 				self._logger.debug('Invoking event callback {}'.format(callback))
 				value = callback(transferred, key, ov)
 			except OSError as e:
-				self._logger.warn('Event callback failed: {}'.format(e))
+				self._logger.warning('Event callback failed: {}'.format(e))
 				f.set_exception(e)
 			else:
 				f.set_result(value)


### PR DESCRIPTION
I get an exception due to IOCP handle being `None` during polling in closing phase, I added some resilience towards that.